### PR TITLE
Fix `waitfor` fcgi

### DIFF
--- a/start-xvfb-nginx.sh
+++ b/start-xvfb-nginx.sh
@@ -53,5 +53,5 @@ if [ -z "$SKIP_NGINX" ] || [ "$SKIP_NGINX" == "false" ] || [ "$SKIP_NGINX" == "0
 fi
 # To avoid issues with GeoPackages when scaling out QGIS should not run as root
 spawn-fcgi -n -u ${QGIS_USER:-www-data} -g ${QGIS_USER:-www-data} -d ${HOME:-/var/lib/qgis} -P /run/qgis.pid -p 9993 -- /usr/lib/cgi-bin/qgis_mapserv.fcgi &
-QGIS_PID=$(waitfor /usr/lib/cgi-bin/qgis_mapserv.fcgi)
+QGIS_PID=$(waitfor qgis_mapserv.fcgi)
 wait $QGIS_PID


### PR DESCRIPTION
Problem statement:

```
docker run -d --rm opengisch/qgis-server
docker exec -it [container id] bash
... kill the fcgi process
... container is not killed and continues to run as a zombie ...
```

Analysis

```
docker run -d --rm opengisch/qgis-server
docker exec -it [container id] bash
root@88dc2b4c8c6c:~# pidof /usr/lib/cgi-bin/qgis_mapserv.fcgi
root@88dc2b4c8c6c:~# pidof qgis_mapserv.fcgi
27
```
