### PR TITLE
remove broken keepalive-workflow to fix nightlies

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -30,8 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: gautamkrishnar/keepalive-workflow@v2
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Hey !

Nightlies broke 2 months ago, it seems because of the use of gautamkrishnar/keepalive-workflow (see https://github.com/gautamkrishnar/keepalive-workflow -> github disabled this repo, unfortunately now we don't have access ).

This PR removes it which should fixes nightlies. Of course this means every 60 days without commits a manual action will be required again.

I'm not sure if there's an easy way to work around this without violating github's TOS...

