### PR TITLE
Fix landing page not accessible via nginx (#130)

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Run qgis_testrunner.sh unit tests
         run: bash tests/test_qgis_testrunner.sh
 
+      - name: Run server landing page config tests
+        run: bash tests/test_server_landing_page.sh
+
   build-nightly:
     needs: test
     runs-on: ubuntu-latest
@@ -70,6 +73,23 @@ jobs:
           docker exec -i qgis-server dpkg -l qgis-server
           sleep 5
           curl -s 'http://localhost:8010/ogc/test_project?service=WMS&request=GetCapabilities' | grep -ivq exception
+          docker rm -f qgis-server
+
+      - name: test server landing page
+        if: ${{ matrix.qgis_type == 'server' }}
+        run: |
+          docker run -d -v $(pwd)/${{ matrix.qgis_type }}/test/data:/io/data -p 8010:80 \
+            -e QGIS_SERVER_LANDING_PAGE_PREFIX=/catalog \
+            -e QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES=/io/data \
+            --name qgis-server-landing qgis/qgis-server:nightly
+          sleep 5
+          # Verify the landing page nginx config was generated
+          docker exec qgis-server-landing test -f /etc/nginx/qgis.d/landing-page.conf
+          # Verify the landing page responds (not a 404)
+          HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' 'http://localhost:8010/catalog/')
+          echo "Landing page HTTP status: ${HTTP_CODE}"
+          [ "$HTTP_CODE" -ne 404 ]
+          docker rm -f qgis-server-landing
 
       - name: test desktop scripts
         if: ${{ matrix.qgis_type == 'desktop' }}

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -54,7 +54,8 @@ ENV DISPLAY :99
 ENV HOME /var/lib/qgis
 
 RUN mkdir $HOME && \
-    chmod 1777 $HOME
+    chmod 1777 $HOME && \
+    mkdir -p /etc/nginx/qgis.d
 WORKDIR $HOME
 
 EXPOSE 80/tcp 9993/tcp

--- a/server/conf/nginx-fcgi-sample.conf
+++ b/server/conf/nginx-fcgi-sample.conf
@@ -84,6 +84,18 @@ http {
         location / {
             root /var/www/html;
         }
+        # Uncomment and adjust the prefix to enable the QGIS Server landing page.
+        # Set QGIS_SERVER_LANDING_PAGE_PREFIX and QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES
+        # environment variables on the qgis-server container accordingly.
+        #location /catalog {
+        #    fastcgi_pass  qgis-fcgi;
+        #    fastcgi_param SCRIPT_FILENAME /usr/lib/cgi-bin/qgis_mapserv.fcgi;
+        #    fastcgi_param QUERY_STRING    $query_string;
+        #    fastcgi_param HTTPS           $qgis_ssl;
+        #    fastcgi_param SERVER_NAME     $qgis_host;
+        #    fastcgi_param SERVER_PORT     $qgis_port;
+        #    include fastcgi_params;
+        #}
         location /ogc/ {
             rewrite ^/ogc/(.*)$ /qgis/qgis_mapserv.fcgi?map=/io/data/$1/$1.qgs;
         }

--- a/server/conf/qgis-server-nginx.conf
+++ b/server/conf/qgis-server-nginx.conf
@@ -73,6 +73,9 @@ http {
         server_name  _;
         root         /usr/share/nginx/html;
 
+        # Include optional server location configs (e.g., landing page)
+        include /etc/nginx/qgis.d/*.conf;
+
         location /ogc/ {
             rewrite ^/ogc/(.*)$ /qgis/qgis_mapserv.fcgi?map=/io/data/$1/$1.qgs;
         }

--- a/server/start-xvfb-nginx.sh
+++ b/server/start-xvfb-nginx.sh
@@ -43,6 +43,30 @@ typeset -l SKIP_NGINX
 rm -f /tmp/.X99-lock
 # Update font cache
 fc-cache
+
+# Generate landing page nginx config if QGIS_SERVER_LANDING_PAGE_PREFIX is set
+if [ -n "${QGIS_SERVER_LANDING_PAGE_PREFIX:-}" ]; then
+    PREFIX="${QGIS_SERVER_LANDING_PAGE_PREFIX}"
+    # Ensure prefix starts with /
+    [[ "$PREFIX" != /* ]] && PREFIX="/${PREFIX}"
+    # Validate prefix to prevent config injection
+    if [[ "$PREFIX" =~ ^/[a-zA-Z0-9/_-]+$ ]]; then
+        cat > /etc/nginx/qgis.d/landing-page.conf <<LANDING_CONF
+location ${PREFIX} {
+    fastcgi_pass  localhost:9993;
+    fastcgi_param SCRIPT_FILENAME /usr/lib/cgi-bin/qgis_mapserv.fcgi;
+    fastcgi_param QUERY_STRING    \$query_string;
+    fastcgi_param HTTPS           \$qgis_ssl;
+    fastcgi_param SERVER_NAME     \$qgis_host;
+    fastcgi_param SERVER_PORT     \$qgis_port;
+    include fastcgi_params;
+}
+LANDING_CONF
+        echo "Landing page nginx config generated for prefix: ${PREFIX}"
+    else
+        echo "WARNING: Invalid QGIS_SERVER_LANDING_PAGE_PREFIX '${PREFIX}'. Must contain only alphanumeric characters, hyphens, underscores, and forward slashes."
+    fi
+fi
 /usr/bin/Xvfb :99 -ac -screen 0 1280x1024x16 +extension GLX +render -noreset >/dev/null &
 XVFB_PID=$(waitfor /usr/bin/Xvfb)
 # Do not start NGINX if environment variable '$SKIP_NGINX' is set but not '0' or 'false'

--- a/tests/test_server_landing_page.sh
+++ b/tests/test_server_landing_page.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Tests for the QGIS Server landing page nginx configuration.
+# Verifies that the start-xvfb-nginx.sh script correctly generates
+# the landing page nginx config snippet based on environment variables.
+#
+# Usage:  bash tests/test_server_landing_page.sh
+# Does not require Docker.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PASS=0
+FAIL=0
+TESTS_RUN=0
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  PASS: ${desc}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: ${desc}"
+        echo "    expected: '${expected}'"
+        echo "    actual:   '${actual}'"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local desc="$1" haystack="$2" needle="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if echo "$haystack" | grep -q "$needle"; then
+        echo "  PASS: ${desc}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: ${desc} — '${needle}' not found in output"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_exists() {
+    local desc="$1" filepath="$2"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ ! -f "$filepath" ]]; then
+        echo "  PASS: ${desc}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: ${desc} — file '${filepath}' exists but should not"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_file_exists() {
+    local desc="$1" filepath="$2"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ -f "$filepath" ]]; then
+        echo "  PASS: ${desc}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: ${desc} — file '${filepath}' not found"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ─── Setup ──────────────────────────────────────────────────────
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf '$TMPDIR'" EXIT
+
+# Create the directory the script writes to
+QGIS_D="${TMPDIR}/etc/nginx/qgis.d"
+mkdir -p "$QGIS_D"
+
+# Extract just the landing page config generation logic from start-xvfb-nginx.sh
+# and test it in isolation.
+generate_landing_page_conf() {
+    # Clean up from previous run
+    rm -f "${QGIS_D}/landing-page.conf"
+
+    if [ -n "${QGIS_SERVER_LANDING_PAGE_PREFIX:-}" ]; then
+        PREFIX="${QGIS_SERVER_LANDING_PAGE_PREFIX}"
+        [[ "$PREFIX" != /* ]] && PREFIX="/${PREFIX}"
+        if [[ "$PREFIX" =~ ^/[a-zA-Z0-9/_-]+$ ]]; then
+            cat > "${QGIS_D}/landing-page.conf" <<LANDING_CONF
+location ${PREFIX} {
+    fastcgi_pass  localhost:9993;
+    fastcgi_param SCRIPT_FILENAME /usr/lib/cgi-bin/qgis_mapserv.fcgi;
+    fastcgi_param QUERY_STRING    \$query_string;
+    fastcgi_param HTTPS           \$qgis_ssl;
+    fastcgi_param SERVER_NAME     \$qgis_host;
+    fastcgi_param SERVER_PORT     \$qgis_port;
+    include fastcgi_params;
+}
+LANDING_CONF
+            return 0
+        else
+            return 1
+        fi
+    fi
+    return 0
+}
+
+echo "=== Landing Page Config Generation Tests ==="
+echo ""
+
+# ─── Test 1: No env var set → no config file ────────────────────
+
+echo "Test 1: No QGIS_SERVER_LANDING_PAGE_PREFIX → no config generated"
+unset QGIS_SERVER_LANDING_PAGE_PREFIX 2>/dev/null || true
+generate_landing_page_conf
+assert_not_exists "no landing-page.conf when prefix unset" "${QGIS_D}/landing-page.conf"
+echo ""
+
+# ─── Test 2: Empty env var → no config file ─────────────────────
+
+echo "Test 2: Empty QGIS_SERVER_LANDING_PAGE_PREFIX → no config generated"
+QGIS_SERVER_LANDING_PAGE_PREFIX=""
+generate_landing_page_conf
+assert_not_exists "no landing-page.conf when prefix empty" "${QGIS_D}/landing-page.conf"
+echo ""
+
+# ─── Test 3: Valid prefix with leading slash ─────────────────────
+
+echo "Test 3: QGIS_SERVER_LANDING_PAGE_PREFIX=/catalog → config generated"
+QGIS_SERVER_LANDING_PAGE_PREFIX="/catalog"
+generate_landing_page_conf
+assert_file_exists "landing-page.conf created" "${QGIS_D}/landing-page.conf"
+CONF=$(cat "${QGIS_D}/landing-page.conf")
+assert_contains "contains location /catalog" "$CONF" "location /catalog {"
+assert_contains "contains fastcgi_pass" "$CONF" "fastcgi_pass  localhost:9993"
+assert_contains "contains SCRIPT_FILENAME" "$CONF" "SCRIPT_FILENAME /usr/lib/cgi-bin/qgis_mapserv.fcgi"
+assert_contains "contains include fastcgi_params" "$CONF" "include fastcgi_params"
+echo ""
+
+# ─── Test 4: Valid prefix without leading slash ──────────────────
+
+echo "Test 4: QGIS_SERVER_LANDING_PAGE_PREFIX=catalog → slash prepended"
+QGIS_SERVER_LANDING_PAGE_PREFIX="catalog"
+generate_landing_page_conf
+assert_file_exists "landing-page.conf created" "${QGIS_D}/landing-page.conf"
+CONF=$(cat "${QGIS_D}/landing-page.conf")
+assert_contains "contains location /catalog" "$CONF" "location /catalog {"
+echo ""
+
+# ─── Test 5: Nested prefix ──────────────────────────────────────
+
+echo "Test 5: QGIS_SERVER_LANDING_PAGE_PREFIX=/ogc/catalog → nested prefix works"
+QGIS_SERVER_LANDING_PAGE_PREFIX="/ogc/catalog"
+generate_landing_page_conf
+assert_file_exists "landing-page.conf created" "${QGIS_D}/landing-page.conf"
+CONF=$(cat "${QGIS_D}/landing-page.conf")
+assert_contains "contains location /ogc/catalog" "$CONF" "location /ogc/catalog {"
+echo ""
+
+# ─── Test 6: Invalid prefix rejected ────────────────────────────
+
+echo "Test 6: Invalid prefix with special chars → config NOT generated"
+QGIS_SERVER_LANDING_PAGE_PREFIX="/cat;alog"
+rm -f "${QGIS_D}/landing-page.conf"
+generate_landing_page_conf || true
+assert_not_exists "no landing-page.conf for invalid prefix" "${QGIS_D}/landing-page.conf"
+echo ""
+
+# ─── Test 7: nginx config has include directive ──────────────────
+
+echo "Test 7: qgis-server-nginx.conf includes qgis.d/*.conf"
+NGINX_CONF="${REPO_DIR}/server/conf/qgis-server-nginx.conf"
+assert_contains "include directive present" "$(cat "$NGINX_CONF")" "include /etc/nginx/qgis.d/\*.conf"
+echo ""
+
+# ─── Summary ────────────────────────────────────────────────────
+
+echo "=== Results: ${PASS} passed, ${FAIL} failed, ${TESTS_RUN} total ==="
+exit $FAIL


### PR DESCRIPTION
The embedded nginx config had no location block to proxy landing page requests (e.g. /catalog) to the QGIS Server FastCGI process, causing 404s.

- Generate landing page nginx location config at startup when QGIS_SERVER_LANDING_PAGE_PREFIX is set, with input validation
- Add include directive for /etc/nginx/qgis.d/*.conf in server block
- Create /etc/nginx/qgis.d directory in Dockerfile
- Add commented landing page example to nginx-fcgi-sample.conf
- Add unit tests for config generation and CI integration test